### PR TITLE
Update README to have correct path for docker build file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Usage:
 
   2) Build heartbleed image once:
 
-     docker build -t <yourname>/heartbleed https://github.com/kasimon/docker-heartbleed.git
+     docker build -t <yourname>/heartbleed https://raw.githubusercontent.com/kasimon/docker-heartbleed/master/Dockerfile
 
   3) Run Heartbleed from image:
 


### PR DESCRIPTION
The docker command fails while building - this fix points at the actual Dockerfile hosted in the repository instead of the git repo itself. I have tested and this fixes the building of the docker container.
